### PR TITLE
fixes deprecated keep_dims

### DIFF
--- a/multi_video_sim/a3c.py
+++ b/multi_video_sim/a3c.py
@@ -16,6 +16,7 @@ class ActorNetwork(object):
     Input to the network is the state, output is the distribution
     of all actions.
     """
+
     def __init__(self, sess, state_dim, action_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -52,11 +53,11 @@ class ActorNetwork(object):
 
         # Compute the objective (log action_vector and entropy)
         self.obj = tf.reduce_sum(tf.mul(
-                       tf.log(tf.reduce_sum(tf.mul(self.out, self.acts),
-                                            reduction_indices=1, keep_dims=True)),
-                       -self.act_grad_weights)) \
-                   + ENTROPY_WEIGHT * tf.reduce_sum(tf.mul(self.out,
-                                                           tf.log(self.out + ENTROPY_EPS)))
+            tf.log(tf.reduce_sum(tf.mul(self.out, self.acts),
+                                 reduction_indices=1, keepdims=True)),
+            -self.act_grad_weights)) \
+            + ENTROPY_WEIGHT * tf.reduce_sum(tf.mul(self.out,
+                                                    tf.log(self.out + ENTROPY_EPS)))
 
         # Combine the gradients here
         self.actor_gradients = tf.gradients(self.obj, self.network_params)
@@ -83,7 +84,8 @@ class ActorNetwork(object):
             flatten_1 = tflearn.flatten(split_4)
             flatten_2 = tflearn.flatten(split_5)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2, flatten_0, flatten_1, flatten_2], 'concat')
+            merge_net = tflearn.merge(
+                [split_0, split_1, split_2, flatten_0, flatten_1, flatten_2], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
 
@@ -99,7 +101,7 @@ class ActorNetwork(object):
     def train(self, inputs, acts, act_grad_weights):
         # there can be only one kind of mask in a training epoch
         for i in xrange(inputs.shape[0]):
-            assert np.all(inputs[0, MASK_DIM, -MAX_BR_LEVELS:] == \
+            assert np.all(inputs[0, MASK_DIM, -MAX_BR_LEVELS:] ==
                           inputs[i, MASK_DIM, -MAX_BR_LEVELS:])
 
         # action dimension matches with mask length
@@ -114,7 +116,7 @@ class ActorNetwork(object):
 
     def predict(self, inputs):
         for i in xrange(inputs.shape[0]):
-            assert np.all(inputs[0, MASK_DIM, -MAX_BR_LEVELS:] == \
+            assert np.all(inputs[0, MASK_DIM, -MAX_BR_LEVELS:] ==
                           inputs[i, MASK_DIM, -MAX_BR_LEVELS:])
 
         return self.sess.run(self.out, feed_dict={
@@ -124,7 +126,7 @@ class ActorNetwork(object):
 
     def get_gradients(self, inputs, acts, act_grad_weights):
         for i in xrange(inputs.shape[0]):
-            assert np.all(inputs[0, MASK_DIM, -MAX_BR_LEVELS:] == \
+            assert np.all(inputs[0, MASK_DIM, -MAX_BR_LEVELS:] ==
                           inputs[i, MASK_DIM, -MAX_BR_LEVELS:])
 
         return self.sess.run(self.actor_gradients, feed_dict={
@@ -153,6 +155,7 @@ class CriticNetwork(object):
     Input to the network is the state and action, output is V(s).
     On policy: the action must be obtained from the output of the Actor network.
     """
+
     def __init__(self, sess, state_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -207,7 +210,8 @@ class CriticNetwork(object):
             flatten_1 = tflearn.flatten(split_4)
             flatten_2 = tflearn.flatten(split_5)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2, flatten_0, flatten_1, flatten_2], 'concat')
+            merge_net = tflearn.merge(
+                [split_0, split_1, split_2, flatten_0, flatten_1, flatten_2], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 100, activation='relu')
             out = tflearn.fully_connected(dense_net_0, 1, activation='linear')

--- a/rl_server/a3c.py
+++ b/rl_server/a3c.py
@@ -15,6 +15,7 @@ class ActorNetwork(object):
     Input to the network is the state, output is the distribution
     of all actions.
     """
+
     def __init__(self, sess, state_dim, action_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -45,11 +46,11 @@ class ActorNetwork(object):
 
         # Compute the objective (log action_vector and entropy)
         self.obj = tf.reduce_sum(tf.multiply(
-                       tf.log(tf.reduce_sum(tf.multiply(self.out, self.acts),
-                                            reduction_indices=1, keep_dims=True)),
-                       -self.act_grad_weights)) \
-                   + ENTROPY_WEIGHT * tf.reduce_sum(tf.multiply(self.out,
-                                                           tf.log(self.out + ENTROPY_EPS)))
+            tf.log(tf.reduce_sum(tf.multiply(self.out, self.acts),
+                                 reduction_indices=1, keepdims=True)),
+            -self.act_grad_weights)) \
+            + ENTROPY_WEIGHT * tf.reduce_sum(tf.multiply(self.out,
+                                                         tf.log(self.out + ENTROPY_EPS)))
 
         # Combine the gradients here
         self.actor_gradients = tf.gradients(self.obj, self.network_params)
@@ -73,7 +74,8 @@ class ActorNetwork(object):
             split_3_flat = tflearn.flatten(split_3)
             split_4_flat = tflearn.flatten(split_4)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2_flat, split_3_flat, split_4_flat, split_5], 'concat')
+            merge_net = tflearn.merge([split_0, split_1, split_2_flat,
+                                       split_3_flat, split_4_flat, split_5], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
             out = tflearn.fully_connected(dense_net_0, self.a_dim, activation='softmax')
@@ -119,6 +121,7 @@ class CriticNetwork(object):
     Input to the network is the state and action, output is V(s).
     On policy: the action must be obtained from the output of the Actor network.
     """
+
     def __init__(self, sess, state_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -171,7 +174,8 @@ class CriticNetwork(object):
             split_3_flat = tflearn.flatten(split_3)
             split_4_flat = tflearn.flatten(split_4)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2_flat, split_3_flat, split_4_flat, split_5], 'concat')
+            merge_net = tflearn.merge([split_0, split_1, split_2_flat,
+                                       split_3_flat, split_4_flat, split_5], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
             out = tflearn.fully_connected(dense_net_0, 1, activation='linear')

--- a/sim/a3c.py
+++ b/sim/a3c.py
@@ -15,6 +15,7 @@ class ActorNetwork(object):
     Input to the network is the state, output is the distribution
     of all actions.
     """
+
     def __init__(self, sess, state_dim, action_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -45,11 +46,11 @@ class ActorNetwork(object):
 
         # Compute the objective (log action_vector and entropy)
         self.obj = tf.reduce_sum(tf.multiply(
-                       tf.log(tf.reduce_sum(tf.multiply(self.out, self.acts),
-                                            reduction_indices=1, keep_dims=True)),
-                       -self.act_grad_weights)) \
-                   + ENTROPY_WEIGHT * tf.reduce_sum(tf.multiply(self.out,
-                                                           tf.log(self.out + ENTROPY_EPS)))
+            tf.log(tf.reduce_sum(tf.multiply(self.out, self.acts),
+                                 reduction_indices=1, keepdims=True)),
+            -self.act_grad_weights)) \
+            + ENTROPY_WEIGHT * tf.reduce_sum(tf.multiply(self.out,
+                                                         tf.log(self.out + ENTROPY_EPS)))
 
         # Combine the gradients here
         self.actor_gradients = tf.gradients(self.obj, self.network_params)
@@ -73,7 +74,8 @@ class ActorNetwork(object):
             split_3_flat = tflearn.flatten(split_3)
             split_4_flat = tflearn.flatten(split_4)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2_flat, split_3_flat, split_4_flat, split_5], 'concat')
+            merge_net = tflearn.merge([split_0, split_1, split_2_flat,
+                                       split_3_flat, split_4_flat, split_5], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
             out = tflearn.fully_connected(dense_net_0, self.a_dim, activation='softmax')
@@ -119,6 +121,7 @@ class CriticNetwork(object):
     Input to the network is the state and action, output is V(s).
     On policy: the action must be obtained from the output of the Actor network.
     """
+
     def __init__(self, sess, state_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -171,7 +174,8 @@ class CriticNetwork(object):
             split_3_flat = tflearn.flatten(split_3)
             split_4_flat = tflearn.flatten(split_4)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2_flat, split_3_flat, split_4_flat, split_5], 'concat')
+            merge_net = tflearn.merge([split_0, split_1, split_2_flat,
+                                       split_3_flat, split_4_flat, split_5], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
             out = tflearn.fully_connected(dense_net_0, 1, activation='linear')

--- a/sim/multi_agent.py
+++ b/sim/multi_agent.py
@@ -2,14 +2,15 @@ import os
 import logging
 import numpy as np
 import multiprocessing as mp
-os.environ['CUDA_VISIBLE_DEVICES']=''
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
 import tensorflow as tf
 import env
 import a3c
 import load_trace
 
 
-S_INFO = 6  # bit_rate, buffer_size, next_chunk_size, bandwidth_measurement(throughput and time), chunk_til_video_end
+# bit_rate, buffer_size, next_chunk_size, bandwidth_measurement(throughput and time), chunk_til_video_end
+S_INFO = 6
 S_LEN = 8  # take how many frames in the past
 A_DIM = 6
 ACTOR_LR_RATE = 0.0001
@@ -17,7 +18,7 @@ CRITIC_LR_RATE = 0.001
 NUM_AGENTS = 16
 TRAIN_SEQ_LEN = 100  # take as a train batch
 MODEL_SAVE_INTERVAL = 100
-VIDEO_BIT_RATE = [300,750,1200,1850,2850,4300]  # Kbps
+VIDEO_BIT_RATE = [300, 750, 1200, 1850, 2850, 4300]  # Kbps
 HD_REWARD = [1, 2, 3, 12, 15, 20]
 BUFFER_NORM_FACTOR = 10.0
 CHUNK_TIL_VIDEO_END_CAP = 48.0
@@ -39,10 +40,10 @@ def testing(epoch, nn_model, log_file):
     # clean up the test results folder
     os.system('rm -r ' + TEST_LOG_FOLDER)
     os.system('mkdir ' + TEST_LOG_FOLDER)
-    
+
     # run test script
     os.system('python rl_test.py ' + nn_model)
-    
+
     # append test performance to the log
     rewards = []
     test_log_files = os.listdir(TEST_LOG_FOLDER)
@@ -129,7 +130,7 @@ def central_agent(net_params_queues, exp_queues):
             total_reward = 0.0
             total_td_loss = 0.0
             total_entropy = 0.0
-            total_agents = 0.0 
+            total_agents = 0.0
 
             # assemble experiences from the agents
             actor_gradient_batch = []
@@ -171,7 +172,7 @@ def central_agent(net_params_queues, exp_queues):
 
             # log training information
             epoch += 1
-            avg_reward = total_reward  / total_agents
+            avg_reward = total_reward / total_agents
             avg_td_loss = total_td_loss / total_batch_len
             avg_entropy = total_entropy / total_batch_len
 
@@ -194,9 +195,9 @@ def central_agent(net_params_queues, exp_queues):
                 save_path = saver.save(sess, SUMMARY_DIR + "/nn_model_ep_" +
                                        str(epoch) + ".ckpt")
                 logging.info("Model saved in file: " + save_path)
-                testing(epoch, 
-                    SUMMARY_DIR + "/nn_model_ep_" + str(epoch) + ".ckpt", 
-                    test_log_file)
+                testing(epoch,
+                        SUMMARY_DIR + "/nn_model_ep_" + str(epoch) + ".ckpt",
+                        test_log_file)
 
 
 def agent(agent_id, all_cooked_time, all_cooked_bw, net_params_queue, exp_queue):
@@ -235,8 +236,8 @@ def agent(agent_id, all_cooked_time, all_cooked_bw, net_params_queue, exp_queue)
             # the action is from the last decision
             # this is to make the framework similar to the real
             delay, sleep_time, buffer_size, rebuf, \
-            video_chunk_size, next_video_chunk_sizes, \
-            end_of_video, video_chunk_remain = \
+                video_chunk_size, next_video_chunk_sizes, \
+                end_of_video, video_chunk_remain = \
                 net_env.get_video_chunk(bit_rate)
 
             time_stamp += delay  # in ms
@@ -245,9 +246,9 @@ def agent(agent_id, all_cooked_time, all_cooked_bw, net_params_queue, exp_queue)
             # -- linear reward --
             # reward is video quality - rebuffer penalty - smoothness
             reward = VIDEO_BIT_RATE[bit_rate] / M_IN_K \
-                     - REBUF_PENALTY * rebuf \
-                     - SMOOTH_PENALTY * np.abs(VIDEO_BIT_RATE[bit_rate] -
-                                               VIDEO_BIT_RATE[last_bit_rate]) / M_IN_K
+                - REBUF_PENALTY * rebuf \
+                - SMOOTH_PENALTY * np.abs(VIDEO_BIT_RATE[bit_rate] -
+                                          VIDEO_BIT_RATE[last_bit_rate]) / M_IN_K
 
             # -- log scale reward --
             # log_bit_rate = np.log(VIDEO_BIT_RATE[bit_rate] / float(VIDEO_BIT_RATE[-1]))
@@ -281,12 +282,14 @@ def agent(agent_id, all_cooked_time, all_cooked_bw, net_params_queue, exp_queue)
             state[2, -1] = float(video_chunk_size) / float(delay) / M_IN_K  # kilo byte / ms
             state[3, -1] = float(delay) / M_IN_K / BUFFER_NORM_FACTOR  # 10 sec
             state[4, :A_DIM] = np.array(next_video_chunk_sizes) / M_IN_K / M_IN_K  # mega byte
-            state[5, -1] = np.minimum(video_chunk_remain, CHUNK_TIL_VIDEO_END_CAP) / float(CHUNK_TIL_VIDEO_END_CAP)
+            state[5, -1] = np.minimum(video_chunk_remain,
+                                      CHUNK_TIL_VIDEO_END_CAP) / float(CHUNK_TIL_VIDEO_END_CAP)
 
             # compute action probability vector
             action_prob = actor.predict(np.reshape(state, (1, S_INFO, S_LEN)))
             action_cumsum = np.cumsum(action_prob)
-            bit_rate = (action_cumsum > np.random.randint(1, RAND_RANGE) / float(RAND_RANGE)).argmax()
+            bit_rate = (action_cumsum > np.random.randint(
+                1, RAND_RANGE) / float(RAND_RANGE)).argmax()
             # Note: we need to discretize the probability into 1/RAND_RANGE steps,
             # because there is an intrinsic discrepancy in passing single state and batch states
 
@@ -364,6 +367,7 @@ def main():
     coordinator.start()
 
     all_cooked_time, all_cooked_bw, _ = load_trace.load_trace(TRAIN_TRACES)
+
     agents = []
     for i in xrange(NUM_AGENTS):
         agents.append(mp.Process(target=agent,

--- a/test/a3c.py
+++ b/test/a3c.py
@@ -15,6 +15,7 @@ class ActorNetwork(object):
     Input to the network is the state, output is the distribution
     of all actions.
     """
+
     def __init__(self, sess, state_dim, action_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -45,11 +46,11 @@ class ActorNetwork(object):
 
         # Compute the objective (log action_vector and entropy)
         self.obj = tf.reduce_sum(tf.multiply(
-                       tf.log(tf.reduce_sum(tf.multiply(self.out, self.acts),
-                                            reduction_indices=1, keep_dims=True)),
-                       -self.act_grad_weights)) \
-                   + ENTROPY_WEIGHT * tf.reduce_sum(tf.multiply(self.out,
-                                                           tf.log(self.out + ENTROPY_EPS)))
+            tf.log(tf.reduce_sum(tf.multiply(self.out, self.acts),
+                                 reduction_indices=1, keepdims=True)),
+            -self.act_grad_weights)) \
+            + ENTROPY_WEIGHT * tf.reduce_sum(tf.multiply(self.out,
+                                                         tf.log(self.out + ENTROPY_EPS)))
 
         # Combine the gradients here
         self.actor_gradients = tf.gradients(self.obj, self.network_params)
@@ -73,7 +74,8 @@ class ActorNetwork(object):
             split_3_flat = tflearn.flatten(split_3)
             split_4_flat = tflearn.flatten(split_4)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2_flat, split_3_flat, split_4_flat, split_5], 'concat')
+            merge_net = tflearn.merge([split_0, split_1, split_2_flat,
+                                       split_3_flat, split_4_flat, split_5], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
             out = tflearn.fully_connected(dense_net_0, self.a_dim, activation='softmax')
@@ -119,6 +121,7 @@ class CriticNetwork(object):
     Input to the network is the state and action, output is V(s).
     On policy: the action must be obtained from the output of the Actor network.
     """
+
     def __init__(self, sess, state_dim, learning_rate):
         self.sess = sess
         self.s_dim = state_dim
@@ -171,7 +174,8 @@ class CriticNetwork(object):
             split_3_flat = tflearn.flatten(split_3)
             split_4_flat = tflearn.flatten(split_4)
 
-            merge_net = tflearn.merge([split_0, split_1, split_2_flat, split_3_flat, split_4_flat, split_5], 'concat')
+            merge_net = tflearn.merge([split_0, split_1, split_2_flat,
+                                       split_3_flat, split_4_flat, split_5], 'concat')
 
             dense_net_0 = tflearn.fully_connected(merge_net, 128, activation='relu')
             out = tflearn.fully_connected(dense_net_0, 1, activation='linear')


### PR DESCRIPTION
_keep_dims_ was deprecated in Tensorflow, and replaced with _keepdims_.
This also fixes some PEP8 issues.