### PR TITLE
Remove wrapping array from initial state set.

### DIFF
--- a/sim/multi_agent.py
+++ b/sim/multi_agent.py
@@ -268,7 +268,7 @@ def agent(agent_id, all_cooked_time, all_cooked_bw, net_params_queue, exp_queue)
 
             # retrieve previous state
             if len(s_batch) == 0:
-                state = [np.zeros((S_INFO, S_LEN))]
+                state = np.zeros((S_INFO, S_LEN))
             else:
                 state = np.array(s_batch[-1], copy=True)
 


### PR DESCRIPTION
Fixes format of initial state when the state batch is empty.